### PR TITLE
RBF kernel not differentiable at 0

### DIFF
--- a/sigkerax/static_kernels.py
+++ b/sigkerax/static_kernels.py
@@ -2,8 +2,8 @@ import jax.numpy as jnp
 
 
 def linear_kernel(x: jnp.ndarray, y: jnp.ndarray, scale: float = 1.0) -> float:
-  return jnp.dot(scale * x, scale * y)
+    return jnp.dot(scale * x, scale * y)
 
 
 def rbf_kernel(x: jnp.ndarray, y: jnp.ndarray, scale: float = 1.0) -> float:
-  return jnp.exp(-jnp.linalg.norm(x - y, ord=2) ** 2 / (2.0 * scale ** 2))
+    return jnp.exp(-jnp.sum((x - y) ** 2) / (2.0 * scale**2))


### PR DESCRIPTION
Changed `jnp.linal.norm(x - y, ord=2) ** 2` to `jnp.sum((x - y) ** 2)` since the former is not differentiable at 0 (because `jnp.linal.norm` is not).